### PR TITLE
Modification du shebang de tests/allShellTests.rb + ajout d'un nix shell pour nixos

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,14 @@
+let
+  pkgs = import <nixpkgs> {};
+in
+  pkgs.mkShell {
+    buildInputs = with pkgs; [
+      ruby
+      rubyPackages.minitest
+      guile
+      readline
+    ];
+    nativeBuildInputs = with pkgs; [
+      pkg-config
+    ];
+  }

--- a/tests/allShellTests.rb
+++ b/tests/allShellTests.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 # Copyright (C) 2013 Gregory Mounie
 # This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
Utiliser `/usr/bin/env` pour le shebang est mieux, car on ne sait pas où est `ruby`

Un nix shell pour nixos